### PR TITLE
Changing the obstacle texture size to 16x16 if larger

### DIFF
--- a/include/map/obstacle.hpp
+++ b/include/map/obstacle.hpp
@@ -32,6 +32,7 @@ public:
         //this->id = obstacle.get_id();
         this->texture = obstacle.get_texture();
         sprite.setTexture(this->texture);
+        sprite.scale(16.0f, 16.0f);
     }
 
     Obstacle(sf::Texture texture, bool collision = false, bool shadow = false) {
@@ -39,6 +40,7 @@ public:
         this->collision = collision;
         this->shadow = shadow;
         sprite.setTexture(this->texture);
+        sprite.scale(16.0f, 16.0f);
     }
 
     ~Obstacle() {


### PR DESCRIPTION
https://github.com/devildefu/pb_battleroyale/projects/1#card-25630683 There will have to be some function updating it everytime you change a texture i suppose.